### PR TITLE
Fork package to @wikimedia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.0.0
+
+* Fully fork into the `wikimedia` project.
+* Upgrade Maki dependency from 0.5 to 7.0, regenerate all icons.
+* Alphanumeric icon generation is done more programmatically.
+
 # 3.0.1
 
 * No longer depending directly on node-mapnik (only node-blend)

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var fs = require('fs'),
-    path = require('path'),
     blend = require('@kartotherian/blend'),
     errcode = require('err-code');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kartotherian/makizushi",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@kartotherian/makizushi",
-  "version": "3.0.2",
-  "description": "professional maki chef",
+  "name": "@wikimedia/makizushi",
+  "version": "4.0.0",
+  "description": "Glue to render Maki icons embedded in a map marker pin",
   "main": "index.js",
   "directories": {
     "test": "test"
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:mapbox/makizushi.git"
+    "url": "git@github.com:wikimedia/makizushi.git"
   },
   "keywords": [
     "maki",
@@ -33,7 +33,7 @@
   "author": "Tom MacWright",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/mapbox/makizushi/issues"
+    "url": "https://phabricator.wikimedia.org/tag/kartotherian/"
   },
-  "homepage": "https://github.com/mapbox/makizushi"
+  "homepage": "https://github.com/wikimedia/makizushi"
 }


### PR DESCRIPTION
Major version change is overdue, and reflects that we've switched to
Maki 7 icons.

Updates the package metadata to reflect that we've forked hard.