### PR TITLE
Cache all symbols

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -3,23 +3,22 @@ var fs = require('fs'),
 
 // Loads up all default markers at require time.
 module.exports = [
-    ['base', 'base'],
-    ['mask', 'mask'],
-    ['alphanum', 'symbol']
+    ['markers-src/base', 'base'],
+    ['markers-src/mask', 'mask'],
+    ['markers-src/alphanum', 'symbol'],
+    ['renders', 'symbol']
 ].reduce(function(memo, destsrc) {
-    var dest = destsrc[1],
-        src = destsrc[0],
-        basepath = path.resolve(__dirname + '/../markers-src/' + src);
+    const [src, dest] = destsrc;
+    const basePath = path.resolve(__dirname, '..', src);
 
-    memo[dest] = fs.readdirSync(basepath)
-        .sort()
+    memo[dest] = fs.readdirSync(basePath)
+        .filter((file) => path.extname(file) === '.png')
         .reduce(function(memo, file) {
-            if (path.extname(file) !== '.png') return memo;
-            var key = path.basename(file, '.png')
+            const key = path.basename(file, '.png')
                 .replace('-11', '-s')
                 .replace('-15', '-m')
                 .replace('-20', '-l');
-            memo[key] = fs.readFileSync(basepath + '/' + file);
+            memo[key] = fs.readFileSync(path.resolve(basePath, file));
             return memo;
         }, memo[dest] || {});
     return memo;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
-var fs = require('fs'),
-    blend = require('@kartotherian/blend'),
+var blend = require('@kartotherian/blend'),
     errcode = require('err-code');
 
 var markerCache = require('./cache');
@@ -13,8 +12,6 @@ var offsets = {
         'm@2x': {x:16,y:12},
         'l@2x': {x:15,y:17}
     };
-var sizes = { s: 11, m: 15, l: 20 },
-    makiRenders = __dirname + '/../renders/';
 
 var aliases = {
     'america-football': 'american-football',
@@ -34,12 +31,6 @@ var aliases = {
     'rail-underground': 'rail-metro',
     'toilets': 'toilet'
 };
-
-var makiAvailable = fs.readdirSync(makiRenders)
-    .reduce(function(mem, file) {
-        mem[file.replace('.png', '')] = true;
-        return mem;
-    }, {});
 
 module.exports = getMarker;
 
@@ -75,82 +66,16 @@ function getMarker(options, callback) {
         options.symbol = aliases[options.symbol];
     }
 
-    if (!options.symbol ||
-        (options.symbol && options.symbol.length === 1) ||
-        (options.symbol.length === 2 && !isNaN(parseInt(options.symbol)))) {
-        loadCached(options, callback);
-    } else {
-        loadMaki(options, callback);
-    }
+    renderMaki(options, callback);
 }
 
 /**
- * Load & composite a marker from the maki icon set.
+ * Load & render a marker.
  *
  * @param {object} options
  * @param {function} callback
  */
-function loadMaki(options, callback) {
-    var base = options.base + '-' + options.size + (options.retina ? '@2x' : ''),
-        size = options.size,
-        symbol = options.symbol + '-' + sizes[size] + (options.retina ? '@2x' : '');
-
-    if (!base || !size) {
-        return callback(errcode('Marker is invalid because it lacks base or size.', 'EINVALID'));
-    }
-
-    if (!makiAvailable[symbol]) {
-        return callback(errcode('Marker symbol "' + options.symbol + '" is invalid.', 'EINVALID'));
-    }
-
-    fs.readFile(makiRenders + symbol + '.png', function(err, data) {
-        if (err) return callback(new Error('Marker "' + JSON.stringify(options) + '" is invalid because the symbol is not found.'));
-
-        // Base marker gets tint applied.
-        var parts = [{
-            buffer: markerCache.base[base],
-            tint: options.parsedTint
-        }];
-
-        // If symbol is present, find correct offset (varies by marker size).
-        if (symbol) {
-            parts.push({
-                buffer: data,
-                tint: options.symbolTint,
-                ...offsets[size + (options.retina ? '@2x' : '')]
-            });
-        }
-
-        // Add mask layer.
-        parts.push({
-            buffer: markerCache.mask[base]
-        });
-
-        // Extract width and height from the IHDR. The IHDR chunk must appear
-        // first, so the location is always fixed.
-        var width = markerCache.base[base].readUInt32BE(16),
-            height = markerCache.base[base].readUInt32BE(20);
-
-        // Combine base, (optional) symbol, to supply the final marker.
-        blend(parts, {
-            format: 'png',
-            quality: 256,
-            width: width,
-            height: height
-        }, function(err, data) {
-            if (err) return callback(err);
-            return callback(null, data);
-        });
-    });
-}
-
-/**
- * Load & generate a cached [a-z0-9] marker.
- *
- * @param {object} options
- * @param {function} callback
- */
-function loadCached(options, callback) {
+function renderMaki(options, callback) {
     var base = options.base + '-' + options.size + (options.retina ? '@2x' : ''),
         size = options.size,
         symbol;


### PR DESCRIPTION
Drops the code path for reading files at runtime.