### PR TITLE
Render empty marker for unknown/invalid icon names

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,6 +47,11 @@ function renderMaki( options, callback ) {
 
 	if ( options.symbol ) {
 		symbol = options.symbol + '-' + options.size + ( options.retina ? '@2x' : '' );
+		if (!markerCache.symbol[symbol]) {
+			// An unknown symbol might as well be a typo. No reason to fail hard. We can still
+			// render something meaningful.
+			symbol = undefined;
+		}
 	}
 
 	if ( !base || !size ) {
@@ -56,11 +61,6 @@ function renderMaki( options, callback ) {
 
 	if ( !markerCache.base[ base ] ) {
 		callback( errcode( 'Marker base "' + options.base + '" is invalid.', 'EINVALID' ) );
-		return;
-	}
-
-	if ( symbol && !markerCache.symbol[ symbol ] ) {
-		callback( errcode( 'Marker symbol "' + options.symbol + '" is invalid.', 'EINVALID' ) );
 		return;
 	}
 


### PR DESCRIPTION
… instead of failing hard and not rendering anything. We can still render something meaningful. Icon names are user input and can easily contain e.g. typos. The missing icon is enough information for an editor to understand that there is an error somewhere.

[Bug: T315226](https://phabricator.wikimedia.org/T315226)