### PR TITLE
Add support for #fff shorthands

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -119,11 +119,11 @@ function getMarker( options, callback ) {
 		// This is not done upstream in `node-tint` as some such
 		// shorthand cannot be disambiguated from other tintspec strings,
 		// e.g. 123 (rgb shorthand) vs. 123 (hue).
-		if ( options.tint.length === 3 ) {
-			options.tint =
-                options.tint[ 0 ] + options.tint[ 0 ] +
-                options.tint[ 1 ] + options.tint[ 1 ] +
-                options.tint[ 2 ] + options.tint[ 2 ];
+		const hex = options.tint.match(/^#?([0-9a-f]{3})$/i);
+		if (hex) {
+			options.tint = hex[1][0] + hex[1][0] +
+				hex[1][1] + hex[1][1] +
+				hex[1][2] + hex[1][2];
 		}
 		options.parsedTint = blend.parseTintString( options.tint );
 		options.symbolTint = contrastingFill( options.tint );


### PR DESCRIPTION
This is intentionally very close to how the upstream parseTintString does it.